### PR TITLE
Compile control fix

### DIFF
--- a/beluga/numeric/compilation/component_compilation.py
+++ b/beluga/numeric/compilation/component_compilation.py
@@ -22,7 +22,7 @@ def compile_control(control_options, args, ham_func, lambdify_func=jit_lambdify)
         compiled_options = lambdify_func(args, control_options)
 
         def calc_u(_y, _p, _k):
-            u_set = np.reshape(compiled_options(_y, _p, _k), (num_options, -1))
+            u_set = np.reshape(np.array(compiled_options(_y, _p, _k)), (num_options, -1))
 
             u = u_set[0, :]
             ham = ham_func(_y, u, _p, _k)

--- a/beluga/numeric/compilation/component_compilation.py
+++ b/beluga/numeric/compilation/component_compilation.py
@@ -22,7 +22,7 @@ def compile_control(control_options, args, ham_func, lambdify_func=jit_lambdify)
         compiled_options = lambdify_func(args, control_options)
 
         def calc_u(_y, _p, _k):
-            u_set = np.array(compiled_options(_y, _p, _k))
+            u_set = np.reshape(compiled_options(_y, _p, _k), (num_options, -1))
 
             u = u_set[0, :]
             ham = ham_func(_y, u, _p, _k)

--- a/beluga/numeric/data_classes/trajectory_mappers.py
+++ b/beluga/numeric/data_classes/trajectory_mappers.py
@@ -204,7 +204,7 @@ class AlgebraicControlMapper(SolMapper):
             ham_func = prob.lambdify(_args_w_control, prob.hamiltonian.expr)
 
             def calc_u(_t, _y, _lam, _p, _k):
-                u_set = np.array(compiled_options(_t, _y, _lam, _p, _k))
+                u_set = np.reshape(compiled_options(_t, _y, _lam, _p, _k), (num_options, -1))
 
                 u = u_set[0, :]
                 ham = ham_func(_t, _y, _lam, u, _p, _k)

--- a/beluga/numeric/data_classes/trajectory_mappers.py
+++ b/beluga/numeric/data_classes/trajectory_mappers.py
@@ -204,7 +204,7 @@ class AlgebraicControlMapper(SolMapper):
             ham_func = prob.lambdify(_args_w_control, prob.hamiltonian.expr)
 
             def calc_u(_t, _y, _lam, _p, _k):
-                u_set = np.reshape(compiled_options(_t, _y, _lam, _p, _k), (num_options, -1))
+                u_set = np.reshape(np.array(compiled_options(_t, _y, _lam, _p, _k)), (num_options, -1))
 
                 u = u_set[0, :]
                 ham = ham_func(_t, _y, _lam, u, _p, _k)


### PR DESCRIPTION
Looks like a bug popped up in the algebraic control mapper due to numpy array slicing. This worked before, but a dependency update may have broken it.

Small fix to ensure `calc_u` has the correct dimensions.

Example output attached. 
[beluga.log](https://github.com/Rapid-Design-of-Systems-Laboratory/beluga/files/8366137/beluga.log)